### PR TITLE
Optimize run times for fast fourier transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.sw[op]
 
 # C extensions
 *.so

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     name="kshape",
     version=__version__,
     description="Python implementation of kshape",
-    packages=find_packages(),
+    packages=find_packages(exclude=["*.tests"]),
     entry_points={}
 )

--- a/tests/test_ncc_c.py
+++ b/tests/test_ncc_c.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from kshape.core import _ncc_c, _ncc_c_2dim, _ncc_c_3dim, zscore
+
+
+def test_ncc_c_2_and_3dim_matches():
+    test = zscore(np.array([
+        [1, 2, 3, 4, 5],
+        [0, 10, 4, 5, 7],
+        [-1, 15, -12, 8, 9],
+    ]), axis=1)
+    centroids = np.array([[1, 1, 0, 1, 1], [10, 12, 0, 0, 1]])
+    distances1 = np.empty((3, 2))
+    distances2 = np.empty((3, 2))
+    for i in range(3):
+        for j in range(2):
+            distances1[i, j] = 1 - _ncc_c(test[i], centroids[j]).max()
+
+    for j in range(2):
+        distances2[:,j] = 1 - _ncc_c_2dim(test, centroids[j]).max(axis=1)
+
+    distances3 = (1 - _ncc_c_3dim(test, centroids).max(axis=2)).T
+
+    assert not (distances1 != distances2).any()
+    assert not (distances2 != distances3).any()


### PR DESCRIPTION
Instead of iterating over each NCCc fourier transform one by one, perform them all at once within the kshape function. This leads to optimized run times, which is especially helpful for larger datasets.