### PR TITLE
Scikit-learn interface and Pytorch 2.0 adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,69 +99,51 @@ We present the runtime performance of *k*-Shape when varying the number of time 
 ## Usage                                                                                                                                     
 
 ### Univariate Example:
-```python
-import numpy as np
-from kshape.core import kshape as ks_cpu
-from kshape.core_gpu import kshape as ks_gpu
+```import numpy as np
+from kshape.core import KShapeClusteringCPU 
+from kshape.core_gpu import KShapeClusteringGPU 
 
 univariate_ts_datasets = np.expand_dims(np.random.rand(200, 60), axis=2)
 num_clusters = 3
 
 # CPU Model
-cpu_model = ks_cpu(univariate_ts_datasets, num_clusters, centroid_init='zero', max_iter=100)
+ksc = KShapeClusteringCPU(num_clusters, centroid_init='zero', max_iter=100, n_jobs=-1)
+ksc.fit(univariate_ts_datasets)
 
-labels = np.zeros(univariate_ts_datasets.shape[0])
-for i in range(num_clusters):
-    labels[cpu_model[i][1]] = i
-    
-cluster_centroids = np.zeros((num_clusters, univariate_ts_datasets.shape[1], univariate_ts_datasets.shape[2]))
-for i in range(num_clusters):
-    cluster_centroids[i] = cpu_model[i][0]
+labels = ksc.labels_ # or ksc.predict(univariate_ts_datasets)
+cluster_centroids = ksc.centroids_
     
     
 # GPU Model
-gpu_model = ks_gpu(univariate_ts_datasets, num_clusters, centroid_init='zero', max_iter=100)
+ksg = KShapeClusteringGPU(num_clusters, centroid_init='zero', max_iter=100)
+ksg.fit(univariate_ts_datasets)
 
-labels = np.zeros(univariate_ts_datasets.shape[0])
-for i in range(num_clusters):
-    labels[gpu_model[i][1]] = i
-    
-cluster_centroids = np.zeros((num_clusters, univariate_ts_datasets.shape[1], univariate_ts_datasets.shape[2]))
-for i in range(num_clusters):
-    cluster_centroids[i] = gpu_model[i][0].detach().cpu()
+labels = ksg.labels_
+cluster_centroids = ksg.centroids_.detach().cpu()
 ```
 
 ### Multivariate Example:
-```python
-import numpy as np
-from kshape.core import kshape as ks_cpu
-from kshape.core_gpu import kshape as ks_gpu
+```import numpy as np
+from kshape.core import KShapeClusteringCPU 
+from kshape.core_gpu import KShapeClusteringGPU 
 
 multivariate_ts_datasets = np.random.rand(200, 60, 6)
 num_clusters = 3
 
 # CPU Model
-cpu_model = ks_cpu(multivariate_ts_datasets, num_clusters, centroid_init='zero', max_iter=100)
+ksc = KShapeClusteringCPU(num_clusters, centroid_init='zero', max_iter=100, n_jobs=-1)
+ksc.fit(univariate_ts_datasets)
 
-labels = np.zeros(multivariate_ts_datasets.shape[0])
-for i in range(num_clusters):
-    labels[cpu_model[i][1]] = i
-    
-cluster_centroids = np.zeros((num_clusters, multivariate_ts_datasets.shape[1], multivariate_ts_datasets.shape[2]))
-for i in range(num_clusters):
-    cluster_centroids[i] = cpu_model[i][0]
+labels = ksc.labels_
+cluster_centroids = ksc.centroids_
     
     
 # GPU Model
-gpu_model = ks_gpu(multivariate_ts_datasets, num_clusters, centroid_init='zero', max_iter=100)
+ksg = KShapeClusteringGPU(num_clusters, centroid_init='zero', max_iter=100)
+ksg.fit(univariate_ts_datasets)
 
-labels = np.zeros(multivariate_ts_datasets.shape[0])
-for i in range(num_clusters):
-    labels[gpu_model[i][1]] = i
-    
-cluster_centroids = np.zeros((num_clusters, multivariate_ts_datasets.shape[1], multivariate_ts_datasets.shape[2]))
-for i in range(num_clusters):
-    cluster_centroids[i] = gpu_model[i][0].detach().cpu()
+labels = ksg.labels_
+cluster_centroids = ksg.centroids_.detach().cpu()
 ```
 
 **Also see [Examples](https://github.com/TheDatumOrg/kshape-python/tree/master/examples) for UCR/UAE dataset clustering**               

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ We present the runtime performance of *k*-Shape when varying the number of time 
 ## Usage                                                                                                                                     
 
 ### Univariate Example:
-```import numpy as np
+``` python
+import numpy as np
 from kshape.core import KShapeClusteringCPU 
 from kshape.core_gpu import KShapeClusteringGPU 
 
@@ -123,7 +124,8 @@ cluster_centroids = ksg.centroids_.detach().cpu()
 ```
 
 ### Multivariate Example:
-```import numpy as np
+``` python
+import numpy as np
 from kshape.core import KShapeClusteringCPU 
 from kshape.core_gpu import KShapeClusteringGPU 
 

--- a/build/lib/kshape/core.py
+++ b/build/lib/kshape/core.py
@@ -4,6 +4,7 @@ import multiprocessing
 from numpy.random import randint
 from numpy.linalg import norm, eigh
 from numpy.fft import fft, ifft
+from sklearn.base import ClusterMixin, BaseEstimator
 
 
 def zscore(a, axis=0, ddof=0):
@@ -82,17 +83,17 @@ def collect_shift(data):
 
 
 def _extract_shape(idx, x, j, cur_center):
-    pool = multiprocessing.Pool()
-    args = []
+    _a=[]
     for i in range(len(idx)):
         if idx[i] == j:
-            args.append([x[i], cur_center])
-    _a = pool.map(collect_shift, args)
-    pool.close()
+            _a.append(collect_shift([x[i], cur_center]))
 
     a = np.array(_a)
+    
     if len(a) == 0:
-        return np.zeros((x.shape[1]))
+        indices = np.random.choice(x.shape[0], 1)
+        return np.squeeze(x[indices].copy())
+        #return np.zeros((x.shape[1]))
 
     columns = a.shape[1]
     y = zscore(a, axis=1, ddof=1)
@@ -115,7 +116,7 @@ def _extract_shape(idx, x, j, cur_center):
     return zscore(centroid, ddof=1)
 
 
-def _kshape(x, k, centroid_init='zero', max_iter=100):
+def _kshape(x, k, centroid_init='zero', max_iter=100, n_jobs=1):
     m = x.shape[0]
     idx = randint(0, k, size=m)
     if centroid_init == 'zero':
@@ -129,9 +130,11 @@ def _kshape(x, k, centroid_init='zero', max_iter=100):
         old_idx = idx
 
         for j in range(k):
-            centroids[j] = np.expand_dims(_extract_shape(idx, x, j, centroids[j]), axis=1)
+            for d in range(x.shape[2]):
+                centroids[j, :, d] = _extract_shape(idx, np.expand_dims(x[:, :, d], axis=2), j, np.expand_dims(centroids[j, :, d], axis=1))
+                #centroids[j] = np.expand_dims(_extract_shape(idx, x, j, centroids[j]), axis=1)
 
-        pool = multiprocessing.Pool()
+        pool = multiprocessing.Pool(n_jobs)
         args = []
         for p in range(m):
             for q in range(k):
@@ -162,6 +165,76 @@ def kshape(x, k, centroid_init='zero', max_iter=100):
         clusters.append((centroid, series))
 
     return clusters
+
+
+
+class KShapeClusteringCPU(ClusterMixin,BaseEstimator):
+    labels_= None
+    centroids_ = None
+
+    def __init__(self,n_clusters, centroid_init='zero', max_iter=100, n_jobs=None):
+        self.n_clusters = n_clusters
+        self.centroid_init = centroid_init
+        self.max_iter = max_iter
+        if n_jobs is None:
+            self.n_jobs=1
+        elif n_jobs == -1:
+            self.n_jobs = multiprocessing.cpu_count()
+        else:
+            self.n_jobs=n_jobs
+        
+
+
+    def fit(self,X,y=None):
+        clusters = self._fit(X,self.n_clusters, self.centroid_init, self.max_iter,self.n_jobs)
+        self.labels_ = np.zeros(X.shape[0])
+        self.centroids_ =np.zeros((self.n_clusters, X.shape[1], X.shape[2]))
+        for i in range(self.n_clusters):
+            self.labels_[clusters[i][1]] = i
+            self.centroids_[i]=clusters[i][0]
+        return self
+
+    def predict(self, X):
+        labels, _ = self._predict(X,self.centroids_)
+        return labels
+        
+    
+    def _predict(self,x, centroids):
+        m = x.shape[0]
+        idx = randint(0, self.n_clusters, size=m)
+        distances = np.empty((m, self.n_clusters))
+        
+
+    
+        pool = multiprocessing.Pool(self.n_jobs)
+        args = []
+        for p in range(m):
+            for q in range(self.n_clusters):
+                args.append([x[p, :], centroids[q, :]])
+        result = pool.map(_ncc_c_3dim, args)
+        pool.close()
+        r = 0
+        for p in range(m):
+            for q in range(self.n_clusters):
+                distances[p, q] = 1 - result[r].max()
+                r = r + 1
+    
+        idx = distances.argmin(1)
+
+        return idx, centroids
+    
+    
+    def _fit(self,x, k, centroid_init='zero', max_iter=100,n_jobs=1):
+        idx, centroids = _kshape(np.array(x), k, centroid_init=centroid_init, max_iter=max_iter, n_jobs=n_jobs)
+        clusters = []
+        for i, centroid in enumerate(centroids):
+            series = []
+            for j, val in enumerate(idx):
+                if i == val:
+                    series.append(j)
+            clusters.append((centroid, series))
+    
+        return clusters
 
 
 if __name__ == "__main__":

--- a/build/lib/kshape/core_gpu.py
+++ b/build/lib/kshape/core_gpu.py
@@ -79,7 +79,7 @@ def _extract_shape(idx, x, j, cur_center):
     p = torch.eye(columns, device="cuda", dtype=torch.float32) - p
 
     m = p.mm(s).mm(p)
-    _, vec = torch.linalg.eig(m)
+    _, vec = torch.linalg.eigh(m,UPLO='U')
     centroid = vec[:, -1]
 
     finddistance1 = torch.norm(a.sub(centroid.reshape((x.shape[1], 1))), 2, dim=(1, 2)).sum()

--- a/examples/cpu-vs-gpu-benchmark.ipynb
+++ b/examples/cpu-vs-gpu-benchmark.ipynb
@@ -44,12 +44,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from kshape.core import kshape\n",
     "from kshape.core import KShapeClusteringCPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "50be2d4c",
    "metadata": {},
    "outputs": [],
@@ -90,6 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from kshape.core_gpu import kshape\n",
     "from kshape.core_gpu import KShapeClusteringGPU"
    ]
   },
@@ -126,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "718f84e2-390c-41f1-b860-07a8b39189a5",
+   "id": "8faa37f4-3f3a-4593-a72b-af70e8fcb88d",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -134,9 +136,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Lux Environment",
+   "display_name": "Python 3.8 env",
    "language": "python",
-   "name": "luxenv"
+   "name": "env-3.8"
   },
   "language_info": {
    "codemirror_mode": {
@@ -148,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/examples/cpu-vs-gpu-benchmark.ipynb
+++ b/examples/cpu-vs-gpu-benchmark.ipynb
@@ -44,12 +44,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kshape.core import kshape"
+    "from kshape.core import KShapeClusteringCPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "50be2d4c",
    "metadata": {},
    "outputs": [],
@@ -57,24 +57,20 @@
     "cpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
-    "    cpu_kshape_model = kshape(ts, 3)\n",
+    "    \n",
+    "    ksc = KShapeClusteringCPU(n_clusters=3,n_jobs=-1)\n",
+    "    ksc.fit(ts)\n",
+    "    print(f'Iteration {i}: time: {time.time() - start_time}')\n",
+    "    \n",
     "    cpu_times.append(time.time() - start_time)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "9d152604",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean CPU Benchmark for 5 Runs: 3082.694662809372\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('Mean CPU Benchmark for 5 Runs:', np.mean(cpu_times))"
    ]
@@ -89,17 +85,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "185d0a7d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kshape.core_gpu import kshape"
+    "from kshape.core_gpu import KShapeClusteringGPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ac173d02",
    "metadata": {},
    "outputs": [],
@@ -107,36 +103,40 @@
     "gpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
-    "    gpu_kshape_model = kshape(ts, 3)\n",
+    "    \n",
+    "    ksg = KShapeClusteringGPU(n_clusters=3)\n",
+    "    ksg.fit(ts)\n",
+    "    print(f'Iteration {i}: time: {time.time() - start_time}')\n",
+    "    \n",
     "    gpu_times.append(time.time() - start_time)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "edff9f0c",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean GPU Benchmark for 5 Runs: 296.60947585105896\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('Mean GPU Benchmark for 5 Runs:', np.mean(gpu_times))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "718f84e2-390c-41f1-b860-07a8b39189a5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Lux Environment",
    "language": "python",
-   "name": "python3"
+   "name": "luxenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -148,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/examples/multivariate_example.ipynb
+++ b/examples/multivariate_example.ipynb
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kshape.core import kshape"
+    "from kshape.core import KShapeClusteringCPU"
    ]
   },
   {
@@ -115,7 +115,10 @@
     "cpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
-    "    cpu_kshape_model = kshape(ts, num_clusters)\n",
+    "    \n",
+    "    ksc = KShapeClusteringCPU(n_clusters=num_clusters,n_jobs=-1)\n",
+    "    ksc.fit(ts)\n",
+    "    \n",
     "    cpu_times.append(time.time() - start_time)"
    ]
   },
@@ -144,13 +147,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = np.zeros(ts.shape[0])\n",
-    "for i in range(num_clusters):\n",
-    "    predictions[cpu_kshape_model[i][1]] = i\n",
+    "predictions = ksc.labels_\n",
     "\n",
-    "cluster_centers = np.zeros((num_clusters, ts.shape[1], ts.shape[2]))\n",
+    "cluster_centers = np.zeros((num_clusters, ts.shape[1], 1))\n",
     "for k in range(num_clusters):\n",
-    "    cluster_centers[k, :, :] = cpu_kshape_model[k][0]"
+    "    cluster_centers[k, :, :] = ksc.centroids_[k"
    ]
   },
   {
@@ -193,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kshape.core_gpu import kshape"
+    "from kshape.core_gpu import KShapeClusteringGPU"
    ]
   },
   {
@@ -206,7 +207,10 @@
     "gpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
-    "    gpu_kshape_model = kshape(ts, num_clusters)\n",
+    "    \n",
+    "    ksg = KShapeClusteringGPU(n_clusters=num_clusters)\n",
+    "    ksg.fit(ts)\n",
+    "    \n",
     "    gpu_times.append(time.time() - start_time)"
    ]
   },
@@ -235,13 +239,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = np.zeros(ts.shape[0])\n",
-    "for i in range(num_clusters):\n",
-    "    predictions[gpu_kshape_model[i][1]] = i\n",
+    "predictions = ksg.labels_\n",
     "\n",
-    "cluster_centers = np.zeros((num_clusters, ts.shape[1], ts.shape[2]))\n",
+    "cluster_centers = np.zeros((num_clusters, ts.shape[1], 1))\n",
     "for k in range(num_clusters):\n",
-    "    cluster_centers[k, :, :] = gpu_kshape_model[k][0].detach().cpu()"
+    "    cluster_centers[k, :, :] = ksg.centroids_[k]"
    ]
   },
   {
@@ -272,9 +274,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Lux Environment",
    "language": "python",
-   "name": "python3"
+   "name": "luxenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -286,7 +288,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/examples/multivariate_example.ipynb
+++ b/examples/multivariate_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "a15d347c",
    "metadata": {},
    "outputs": [],
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "82b89129",
    "metadata": {},
    "outputs": [],
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "ae5b17a2",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "fa09d7d9",
    "metadata": {},
    "outputs": [],
@@ -97,17 +97,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "b4f80e83",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from kshape.core import kshape\n",
     "from kshape.core import KShapeClusteringCPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "3903b208",
    "metadata": {},
    "outputs": [],
@@ -124,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "c914e225",
    "metadata": {},
    "outputs": [
@@ -132,7 +133,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean CPU Benchmark for 5 Runs: 1182.4650375843048\n"
+      "Mean CPU Benchmark for 5 Runs: 2.1556129932403563\n"
      ]
     }
    ],
@@ -142,21 +143,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "id": "249f17fd",
    "metadata": {},
    "outputs": [],
    "source": [
     "predictions = ksc.labels_\n",
     "\n",
-    "cluster_centers = np.zeros((num_clusters, ts.shape[1], 1))\n",
+    "cluster_centers = np.zeros((num_clusters, ts.shape[1], ts.shape[2]))\n",
     "for k in range(num_clusters):\n",
-    "    cluster_centers[k, :, :] = ksc.centroids_[k"
+    "    cluster_centers[k, :, :] = ksc.centroids_[k]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "id": "75cb8189",
    "metadata": {},
    "outputs": [
@@ -164,9 +165,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rand Score: 0.8300454160386519\n",
-      "Adjusted Rand Score: 0.1279219457884177\n",
-      "Normalized Mutual Information: 0.19734751142416793\n"
+      "Rand Score: 1.0\n",
+      "Adjusted Rand Score: 1.0\n",
+      "Normalized Mutual Information: 1.0\n"
      ]
     }
    ],
@@ -189,17 +190,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "48fcba7f",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from kshape.core_gpu import kshape\n",
     "from kshape.core_gpu import KShapeClusteringGPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "6c72ddff",
    "metadata": {},
    "outputs": [],
@@ -216,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "5f8eb143",
    "metadata": {},
    "outputs": [
@@ -224,7 +226,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean GPU Benchmark for 5 Runs: 5687.338460683823\n"
+      "Mean GPU Benchmark for 5 Runs: 6.8629984855651855\n"
      ]
     }
    ],
@@ -234,16 +236,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "94d1d612",
    "metadata": {},
    "outputs": [],
    "source": [
     "predictions = ksg.labels_\n",
     "\n",
-    "cluster_centers = np.zeros((num_clusters, ts.shape[1], 1))\n",
+    "cluster_centers = np.zeros((num_clusters, ts.shape[1], ts.shape[2]))\n",
     "for k in range(num_clusters):\n",
-    "    cluster_centers[k, :, :] = ksg.centroids_[k]"
+    "    cluster_centers[k, :, :] = ksg.centroids_[k].detach().cpu()"
    ]
   },
   {
@@ -256,9 +258,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rand Score: 0.8260587762112686\n",
-      "Adjusted Rand Score: 0.11377073826893268\n",
-      "Normalized Mutual Information: 0.18563626255616614\n"
+      "Rand Score: 1.0\n",
+      "Adjusted Rand Score: 1.0\n",
+      "Normalized Mutual Information: 1.0\n"
      ]
     }
    ],
@@ -270,13 +272,101 @@
     "nmi_ks = normalized_mutual_info_score(predictions, labels)\n",
     "print('Normalized Mutual Information:', nmi_ks)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7370c585-d942-4a81-acb8-0d8c50b9106c",
+   "metadata": {},
+   "source": [
+    "# TSLearn Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "6e909999-0090-4a72-a6aa-c2279e9afc75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tslearn.clustering import KShape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "78ceb640-a3c6-4acc-b3dd-b2be0e91cbcf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsl_times=[]\n",
+    "for i in range(5):\n",
+    "    start_time = time.time()\n",
+    "    \n",
+    "    start_time = time.time()\n",
+    "    ks = KShape(n_clusters=num_clusters, n_init=1, random_state=0).fit(ts)\n",
+    "\n",
+    "    tsl_times.append(time.time() - start_time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "5dcf0280-648d-4ecc-9f47-697ad3210e5a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean TSLearn Benchmark for 5 Runs: 14.150329494476319\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Mean TSLearn Benchmark for 5 Runs:', np.mean(tsl_times))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "012de396-3c04-4435-9f6d-c8703f957e3c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rand Score: 1.0\n",
+      "Adjusted Rand Score: 1.0\n",
+      "Normalized Mutual Information: 1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "predictions = ks.labels_\n",
+    "\n",
+    "ri_ks = rand_score(predictions, labels)\n",
+    "print('Rand Score:', ri_ks)\n",
+    "ari_ks = adjusted_rand_score(predictions, labels)\n",
+    "print('Adjusted Rand Score:', ari_ks)\n",
+    "nmi_ks = normalized_mutual_info_score(predictions, labels)\n",
+    "print('Normalized Mutual Information:', nmi_ks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5aee678c-2a5b-4a14-b3d4-d9bf769af9f3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Lux Environment",
+   "display_name": "Python 3.8 env",
    "language": "python",
-   "name": "luxenv"
+   "name": "env-3.8"
   },
   "language_info": {
    "codemirror_mode": {
@@ -288,7 +378,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/examples/univariate_example.ipynb
+++ b/examples/univariate_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "29fc0df0",
    "metadata": {},
    "outputs": [],
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "76e74dbe",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "2c5914e7",
    "metadata": {},
    "outputs": [],
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "3c4f7152",
    "metadata": {},
    "outputs": [],
@@ -83,17 +83,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "d6d5b701",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kshape.core import kshape"
+    "from kshape.core import KShapeClusteringCPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "a33244d6",
    "metadata": {},
    "outputs": [],
@@ -101,60 +101,44 @@
     "cpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
-    "    cpu_kshape_model = kshape(np.expand_dims(ts, axis=2), num_clusters)\n",
+    "\n",
+    "    ksc = KShapeClusteringCPU(n_clusters=num_clusters,max_iter = 1,n_jobs=-1)\n",
+    "    ksc.fit(np.expand_dims(ts, axis=2))\n",
+    "    print(f'Iteration {i}: time: {time.time() - start_time}')\n",
+    "    \n",
     "    cpu_times.append(time.time() - start_time)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "43a3bb3b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean CPU Benchmark for 5 Runs: 2527.477051258087\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('Mean CPU Benchmark for 5 Runs:', np.mean(cpu_times))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "df9d19ae",
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = np.zeros(ts.shape[0])\n",
-    "for i in range(num_clusters):\n",
-    "    predictions[cpu_kshape_model[i][1]] = i\n",
+    "predictions = ksc.labels_\n",
     "\n",
     "cluster_centers = np.zeros((num_clusters, ts.shape[1], 1))\n",
     "for k in range(num_clusters):\n",
-    "    cluster_centers[k, :, :] = cpu_kshape_model[k][0]"
+    "    cluster_centers[k, :, :] = ksc.centroids_[k]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "4c2101fc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Rand Score: 0.9241423149575677\n",
-      "Adjusted Rand Score: 0.2446950839815576\n",
-      "Normalized Mutual Information: 0.4313775426755777\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ri_ks = rand_score(predictions, labels)\n",
     "print('Rand Score:', ri_ks)\n",
@@ -174,17 +158,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "653448fe",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kshape.core_gpu import kshape"
+    "from kshape.core_gpu import KShapeClusteringGPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "e1634a99",
    "metadata": {},
    "outputs": [],
@@ -192,60 +176,44 @@
     "gpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
-    "    gpu_kshape_model = kshape(np.expand_dims(ts, axis=2), num_clusters)\n",
+    "    \n",
+    "    ksg = KShapeClusteringGPU(n_clusters=num_clusters)\n",
+    "    ksg.fit(np.expand_dims(ts, axis=2))\n",
+    "    print(f'Iteration {i}: time: {time.time() - start_time}')\n",
+    "    \n",
     "    gpu_times.append(time.time() - start_time)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "94f0b6c8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean GPU Benchmark for 5 Runs: 33078.67823410034\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('Mean GPU Benchmark for 5 Runs:', np.mean(gpu_times))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "d6af5a8a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = np.zeros(ts.shape[0])\n",
-    "for i in range(num_clusters):\n",
-    "    predictions[gpu_kshape_model[i][1]] = i\n",
+    "predictions = ksg.labels_\n",
     "\n",
     "cluster_centers = np.zeros((num_clusters, ts.shape[1], 1))\n",
     "for k in range(num_clusters):\n",
-    "    cluster_centers[k, :, :] = gpu_kshape_model[k][0].detach().cpu()"
+    "    cluster_centers[k, :, :] = ksg.centroids_[k]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "4c4ec37e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Rand Score: 0.9350468352848035\n",
-      "Adjusted Rand Score: 0.24933303905728887\n",
-      "Normalized Mutual Information: 0.4350312365117842\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ri_ks = rand_score(predictions, labels)\n",
     "print('Rand Score:', ri_ks)\n",
@@ -254,13 +222,21 @@
     "nmi_ks = normalized_mutual_info_score(predictions, labels)\n",
     "print('Normalized Mutual Information:', nmi_ks)                                                                                                                                                         "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae0c9e21-ac96-44ce-b59e-f31af9ad0628",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Lux Environment",
    "language": "python",
-   "name": "python3"
+   "name": "luxenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -272,7 +248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/examples/univariate_example.ipynb
+++ b/examples/univariate_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "29fc0df0",
    "metadata": {},
    "outputs": [],
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "76e74dbe",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "2c5914e7",
    "metadata": {},
    "outputs": [],
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "3c4f7152",
    "metadata": {},
    "outputs": [],
@@ -83,26 +83,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "d6d5b701",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from kshape.core import kshape\n",
     "from kshape.core import KShapeClusteringCPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "a33244d6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration 0: time: 995.6358451843262\n",
+      "Iteration 1: time: 832.5988781452179\n",
+      "Iteration 2: time: 997.8731744289398\n",
+      "Iteration 3: time: 506.3470458984375\n",
+      "Iteration 4: time: 915.2455561161041\n"
+     ]
+    }
+   ],
    "source": [
     "cpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
     "\n",
-    "    ksc = KShapeClusteringCPU(n_clusters=num_clusters,max_iter = 1,n_jobs=-1)\n",
+    "    ksc = KShapeClusteringCPU(n_clusters=num_clusters,max_iter=100,n_jobs=-1)\n",
     "    ksc.fit(np.expand_dims(ts, axis=2))\n",
     "    print(f'Iteration {i}: time: {time.time() - start_time}')\n",
     "    \n",
@@ -111,17 +124,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "43a3bb3b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean CPU Benchmark for 5 Runs: 849.5401813030243\n"
+     ]
+    }
+   ],
    "source": [
     "print('Mean CPU Benchmark for 5 Runs:', np.mean(cpu_times))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "df9d19ae",
    "metadata": {},
    "outputs": [],
@@ -135,10 +156,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "4c2101fc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rand Score: 0.9258831895773435\n",
+      "Adjusted Rand Score: 0.24634633355841157\n",
+      "Normalized Mutual Information: 0.43663386420321454\n"
+     ]
+    }
+   ],
    "source": [
     "ri_ks = rand_score(predictions, labels)\n",
     "print('Rand Score:', ri_ks)\n",
@@ -158,11 +189,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "653448fe",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from kshape.core_gpu import kshape\n",
     "from kshape.core_gpu import KShapeClusteringGPU"
    ]
   },
@@ -176,8 +208,7 @@
     "gpu_times = []\n",
     "for i in range(5):\n",
     "    start_time = time.time()\n",
-    "    \n",
-    "    ksg = KShapeClusteringGPU(n_clusters=num_clusters)\n",
+    "    ksg = KShapeClusteringGPU(n_clusters=num_clusters,max_iter=100)\n",
     "    ksg.fit(np.expand_dims(ts, axis=2))\n",
     "    print(f'Iteration {i}: time: {time.time() - start_time}')\n",
     "    \n",
@@ -205,7 +236,7 @@
     "\n",
     "cluster_centers = np.zeros((num_clusters, ts.shape[1], 1))\n",
     "for k in range(num_clusters):\n",
-    "    cluster_centers[k, :, :] = ksg.centroids_[k]"
+    "    cluster_centers[k, :, :] = ksg.centroids_[k].detach().cpu()"
    ]
   },
   {
@@ -234,9 +265,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Lux Environment",
+   "display_name": "Python 3.8 env",
    "language": "python",
-   "name": "luxenv"
+   "name": "env-3.8"
   },
   "language_info": {
    "codemirror_mode": {
@@ -248,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/kshape/core_gpu.py
+++ b/kshape/core_gpu.py
@@ -79,7 +79,7 @@ def _extract_shape(idx, x, j, cur_center):
     p = torch.eye(columns, device="cuda", dtype=torch.float32) - p
 
     m = p.mm(s).mm(p)
-    _, vec = torch.linalg.eigh(m)
+    _, vec = torch.linalg.eigh(m,UPLO='U')
     centroid = vec[:, -1]
 
     finddistance1 = torch.norm(a.sub(centroid.reshape((x.shape[1], 1))), 2, dim=(1, 2)).sum()

--- a/kshape/core_gpu.py
+++ b/kshape/core_gpu.py
@@ -1,15 +1,19 @@
 import math
 import torch
 import numpy as np
-
+from sklearn.base import ClusterMixin, BaseEstimator
 
 def zscore(a, axis=0, ddof=0):
     mns = a.mean(dim=axis)
     sstd = a.std(dim=axis, unbiased=(ddof == 1))
     if axis and mns.dim() < a.dim():
-        return torch.nan_to_num((a - mns.unsqueeze(axis)).div(sstd.unsqueeze(axis)))
+        x=(a - mns.unsqueeze(axis)).div(sstd.unsqueeze(axis))
+        return x.masked_fill(torch.isnan(x), 0)
+        #return torch.nan_to_num((a - mns.unsqueeze(axis)).div(sstd.unsqueeze(axis)))
     else:
-        return torch.nan_to_num(a.sub_(mns).div(sstd))
+        x=a.sub_(mns).div(sstd)
+        return x.masked_fill(torch.isnan(x), 0)
+        #return torch.nan_to_num(a.sub_(mns).div(sstd))
 
 
 def roll_zeropad(a, shift, axis=None):
@@ -75,7 +79,7 @@ def _extract_shape(idx, x, j, cur_center):
     p = torch.eye(columns, device="cuda", dtype=torch.float32) - p
 
     m = p.mm(s).mm(p)
-    _, vec = torch.symeig(m, eigenvectors=True)
+    _, vec = torch.linalg.eigh(m)
     centroid = vec[:, -1]
 
     finddistance1 = torch.norm(a.sub(centroid.reshape((x.shape[1], 1))), 2, dim=(1, 2)).sum()
@@ -85,6 +89,7 @@ def _extract_shape(idx, x, j, cur_center):
         centroid.mul_(-1)
 
     return zscore(centroid, ddof=1)
+
 
 def _kshape(x, k, centroid_init='zero', max_iter=100):
     m = x.shape[0]
@@ -113,8 +118,7 @@ def _kshape(x, k, centroid_init='zero', max_iter=100):
             break
 
     return idx, centroids
-
-
+    
 def kshape(x, k, centroid_init='zero', max_iter=100):
     x = torch.tensor(x, device="cuda", dtype=torch.float32)
     idx, centroids = _kshape(x, k, centroid_init=centroid_init, max_iter=max_iter)
@@ -127,6 +131,62 @@ def kshape(x, k, centroid_init='zero', max_iter=100):
         clusters.append((centroid, series))
 
     return clusters
+
+class KShapeClusteringGPU(ClusterMixin,BaseEstimator):
+    labels_= None
+    centroids_ = None
+
+    def __init__(self,n_clusters, centroid_init='zero', max_iter=100):
+        self.n_clusters = n_clusters
+        self.centroid_init = centroid_init
+        self.max_iter = max_iter
+
+
+    def fit(self,X,y=None):
+        clusters = self._fit(X,self.n_clusters, self.centroid_init, self.max_iter)
+        self.labels_ = np.zeros(X.shape[0])
+        self.centroids_ =torch.zeros(self.n_clusters, X.shape[1], X.shape[2], device="cuda", dtype=torch.float32)
+        for i in range(self.n_clusters):
+            self.labels_[clusters[i][1]] = i
+            self.centroids_[i]=clusters[i][0]
+        return self
+
+    def predict(self, X):
+        labels, _ = self._predict(X,self.centroids_)
+        return labels
+        
+    
+    def _predict(self,x, centroids):
+        x = torch.tensor(x, device="cuda", dtype=torch.float32)
+        m = x.shape[0]
+        k=len(centroids)
+        idx = torch.randint(0, self.n_clusters, (m,), dtype=torch.float32).to("cuda")
+        distances = torch.empty(m, self.n_clusters, device="cuda")
+                
+        for i, ts in enumerate(x):
+            for c, ct in enumerate(centroids):
+                dist = 1 - _ncc_c_3dim(ts, ct).max()
+                distances[i, c] = dist
+            
+        idx = distances.argmin(1)
+    
+    
+        return idx, centroids
+    
+    
+    def _fit(self,x, k, centroid_init='zero', max_iter=100):
+        x = torch.tensor(x, device="cuda", dtype=torch.float32)
+        idx, centroids = _kshape(x, k, centroid_init=centroid_init, max_iter=max_iter)
+        clusters = []
+        for i, centroid in enumerate(centroids):
+            series = []
+            for j, val in enumerate(idx):
+                if i == val:
+                    series.append(j)
+            clusters.append((centroid, series))
+    
+        return clusters
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following changes were made to the original code:
  * Scikit-learn based interface with fit/predict functions added for easier usage. Added `labels_` and `centroids_` attributes of two classes `KShapeClustering CPU` and `KShapeClustering GPU`.
  * Added `n_jobs` parameter which allows to adjust number of processes in multiprocessing calculations
  * Fix issue #14 which used depreciated `symeig` function. It was changed to `torch.linalg.eigh` which is equivalent. 
  * Fix issue with `nan_to_num_cuda` error for complex numbers that were returned by `eigh` function
  * Fix issue with multiprocessing pool added in `_extract_shape` function. The multiprocessing at this point was removed which speeds up computations a lot
  